### PR TITLE
Add a CODEOWNER file

### DIFF
--- a/moduleroot/.github/CODEOWNERS.erb
+++ b/moduleroot/.github/CODEOWNERS.erb
@@ -1,0 +1,1 @@
+* @opus-codium/sysadmins


### PR DESCRIPTION
We used to rely on assignees.io to assign Pull-Requests to developers
but the service is EOL.  GitHub introduced similar feature last year:
https://help.github.com/articles/about-codeowners/