### PR TITLE
Update Travis-CI build matrix

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -1,19 +1,24 @@
 ---
 language: "ruby"
 script: "bundle exec rake rubocop validate lint spec"
-rvm:
-  - 2.3
-  - 2.4
-  - 2.5
-env:
-<%- if @configs.dig('test_with_debian_puppet', 'stretch') -%>
-  - PUPPET_VERSION='4.8.2'
-<%- end -%>
-<%- if @configs.dig('test_with_debian_puppet', 'buster') -%>
-  - PUPPET_VERSION='5.4.0'
-<%- end -%>
-  - PUPPET_VERSION='~> 4.0'
-  - PUPPET_VERSION='~> 5.0'
+matrix:
+  include:
+  <%- if @configs.dig('test_with_debian_puppet', 'stretch') -%>
+  - name: "Debian Stretch"
+    rvm: "2.3.3"
+    env: PUPPET_VERSION='4.8.2'
+  <%- end -%>
+  <%- if @configs.dig('test_with_debian_puppet', 'buster') -%>
+  - name: "Debian Buster"
+    rvm: "2.5.1"
+    env: PUPPET_VERSION='5.4.0'
+  <%- end -%>
+  - name: "Puppet 5"
+    rvm: "2.4.4"
+    env: PUPPET_VERSION='~> 5.0'
+  - name: "Puppet 6"
+    rvm: "2.5.1"
+    env: PUPPET_VERSION='~> 6.0'
 notifications:
   email:
     - sysadmins@opus-codium.fr

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -11,7 +11,7 @@ matrix:
   <%- if @configs.dig('test_with_debian_puppet', 'buster') -%>
   - name: "Debian Buster"
     rvm: "2.5.1"
-    env: PUPPET_VERSION='5.4.0'
+    env: PUPPET_VERSION='5.5.6'
   <%- end -%>
   - name: "Puppet 5"
     rvm: "2.4.4"

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -26,5 +26,5 @@ group <%= group %> do
 end
 <%- end -%>
 
-puppetversion = ENV['PUPPET_VERSION'] || '~> 5.0'
+puppetversion = ENV['PUPPET_VERSION'] || '~> 6.0'
 gem 'puppet', puppetversion


### PR DESCRIPTION
Puppet 6.0 has been released and Puppet 4.x will be EOL soon.  Update the build
matrix accordingly.  For now, keep the Debian-specific Puppet version (and also
test using the proper Ruby version).