### PR TITLE
Silent fatal errors when modules have no tags

### DIFF
--- a/bin/count-unreleased-commits
+++ b/bin/count-unreleased-commits
@@ -1,9 +1,12 @@
 #!/bin/sh
 # Stolen from https://github.com/voxpupuli/modulesync_config
 
-set -e
-
 for module in modules/* ; do
-  count=$(git --git-dir "${module}/.git" log "$(git --git-dir "${module}/.git" describe --tags --abbrev=0)"..HEAD --oneline | wc -l)
-  printf '%-40s %3d\n' "$module" $count
+  last_tag=$(git --git-dir "${module}/.git" describe --tags --abbrev=0 2> /dev/null)
+  if [ $? -eq 0 ]; then
+    count=$(git --git-dir "${module}/.git" log ${last_tag}..HEAD --oneline | wc -l)
+    printf '%-40s %3d\n' "$module" $count
+  else
+    printf '%-40s N/A\n' "$module"
+  fi
 done


### PR DESCRIPTION
Fixes
```
fatal: No names found, cannot describe anything.
modules/puppet-firefox                     0
fatal: No names found, cannot describe anything.
modules/puppet-lincall                     0
fatal: No names found, cannot describe anything.
modules/puppet-openproject                 0
[...]
```