### PR TITLE
Add gem to lint param types

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -11,6 +11,7 @@ Gemfile:
         version_var: FACTER_GEM_VERSION
       - gem: puppet-lint-classes_and_types_beginning_with_digits-check
       - gem: puppet-lint-leading_zero-check
+      - gem: puppet-lint-param-types
       - gem: puppet-lint-trailing_comma-check
       - gem: puppet-lint-unquoted_string-check
       - gem: puppet-lint-variable_contains_upcase


### PR DESCRIPTION
As suggested in https://github.com/opus-codium/puppet-taiga/pull/17 this PR add a param types linter for all modulesync_config driven repos.