### PR TITLE
Fix Rubocop Layout/LineLength

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -4,7 +4,7 @@
 Layout/HashAlignment:
   Description: Be consistent with Puppet's style
   EnforcedHashRocketStyle: table
-Metrics/LineLength:
+Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
 Metrics/BlockLength:


### PR DESCRIPTION
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout