### PR TITLE
Fix utility scripts

### DIFF
--- a/bin/count-unreleased-commits
+++ b/bin/count-unreleased-commits
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Stolen from https://github.com/voxpupuli/modulesync_config
 
-for module in modules/* ; do
+for module in modules/*/* ; do
   last_tag=$(git --git-dir "${module}/.git" describe --tags --abbrev=0 2> /dev/null)
   if [ $? -eq 0 ]; then
     count=$(git --git-dir "${module}/.git" log ${last_tag}..HEAD --oneline | wc -l)

--- a/bin/create-pull-requests
+++ b/bin/create-pull-requests
@@ -8,8 +8,9 @@ if ! which hub > /dev/null ; then
 fi
 
 version=$(git describe --exact-match --tags)
-for module in modules/* ; do
-  (cd "$module"
-  hub pull-request -m "modulesync ${version}"
+for module in modules/*/* ; do
+  (
+    cd "$module"
+    hub pull-request -m "modulesync ${version}"
   )
 done


### PR DESCRIPTION
The recent ModuleSync update changed the hierarchy of the modules,
breaking the scripts which are part of the repo.  This fixes the
problem.