### PR TITLE
Update Ruby versions

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -16,10 +16,10 @@ matrix:
     env: PUPPET_VERSION='5.5.6'
   <%- end -%>
   - name: "Puppet 5"
-    rvm: "2.4.5"
+    rvm: "2.4.9"
     env: PUPPET_VERSION='~> 5.0'
   - name: "Puppet 6"
-    rvm: "2.5.3"
+    rvm: "2.5.7"
     env: PUPPET_VERSION='~> 6.0'
 notifications:
   email:


### PR DESCRIPTION
The version of Ruby shipped with puppet-agent has been changed.  use the
same version for running the test suites for consistency.