### PR TITLE
Fix Rubocop Style/TrailingCommaInArrayLiteral

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -11,6 +11,9 @@ Metrics/BlockLength:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+Style/TrailingCommaInArrayLiteral:
+  Description: Be consistent with Puppet's style
+  EnforcedStyleForMultiline: comma
 Style/TrailingCommaInHashLiteral:
   Description: Be consistent with Puppet's style
   EnforcedStyleForMultiline: comma


### PR DESCRIPTION
We want a comma after the last Array literal as per Puppet's convention,
and as is done for Hash and for arguments.