### PR TITLE
Add support for gihub-changelog-generator

### DIFF
--- a/bin/create-pull-requests
+++ b/bin/create-pull-requests
@@ -11,6 +11,6 @@ version=$(git describe --exact-match --tags)
 for module in modules/*/* ; do
   (
     cd "$module"
-    hub pull-request -m "modulesync ${version}"
+    hub pull-request -l modulesync -m "modulesync ${version}"
   )
 done

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -9,6 +9,7 @@ Gemfile:
       - gem: facter
         version: '~> 2.0'
         version_var: FACTER_GEM_VERSION
+      - gem: github_changelog_generator
       - gem: metadata-json-lint
       - gem: puppet-lint-classes_and_types_beginning_with_digits-check
       - gem: puppet-lint-leading_zero-check

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -18,3 +18,15 @@ task 'lint:auto_correct' do
   PuppetLint.configuration.fix = true
   Rake::Task[:lint].invoke
 end
+
+require 'github_changelog_generator/task'
+
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  pieces = `git config --get remote.origin.url`.chomp.delete_suffix('.git').split(%r{/|:})
+  config.user = pieces[-2]
+  config.project = pieces[-1]
+  config.since_tag = '1.0.0'
+  config.exclude_labels = ['ignore', 'modulesync']
+  config.future_release = ENV['FUTURE_RELEASE']
+  config.unreleased = !ENV['FUTURE_RELEASE'].nil?
+end


### PR DESCRIPTION
Instead of managing each module CHANGELOG.md file by hand, rely on
gihub-changelog-generator and GitHub labels to manage it automatically.

We will loose some information for older releases, but now that we
consistently use PR to fix issues and add features, it is not a big deal
IMHO.