### PR TITLE
Do not use String#delete_suffix

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -22,7 +22,7 @@ end
 require 'github_changelog_generator/task'
 
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  pieces = `git config --get remote.origin.url`.chomp.delete_suffix('.git').split(%r{/|:})
+  pieces = `git config --get remote.origin.url`.chomp.sub(/\.git\z/, '').split(%r{/|:})
   config.user = pieces[-2]
   config.project = pieces[-1]
   config.since_tag = '1.0.0'


### PR DESCRIPTION
String#delete_suffix was added in Ruby 2.5, but older Puppet use Ruby
2.4 where the function is not available.