### PR TITLE
Switch from Travis-CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+---
+name: Continuous Integration
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - 2.5
+          - 2.6
+          - 2.7
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ruby }}-gems-
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs $(nproc) --retry 3
+      - name: Run tests
+        run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
----
-language: ruby
-notifications:
-  email:
-    - sysadmins@opus-codium.fr


### PR DESCRIPTION
Test-drive GitHub Actions

[Travis-CI has decided to adjust its business model in a way that Open Source projects buy CI minutes each month](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing).  I currently have no idea of the amount of time the CI runs take, but before consuming all the free trial we are forced into, consider alternatives.