### PR TITLE
Rebase modulesync branch on top of origin/master

### DIFF
--- a/bin/rebase-on-master
+++ b/bin/rebase-on-master
@@ -9,7 +9,7 @@ for repo in modules/*/*; do
 	(
 		cd $repo
 		git fetch --all
-		git rebase master
+		git rebase origin/master
 		git push -f origin modulesync
 	)
 done


### PR DESCRIPTION
Rebasing on `master` has no effect until it's pulled from the remote.