### PR TITLE
Only run CI on PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@
 name: Continuous Integration
 
 on:
-  - push
   - pull_request
 
 jobs:


### PR DESCRIPTION
When runnign on commits and CI, we end-up running each test twice wich add no value.