### PR TITLE
Do not prepend a 'v' to future version

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -25,8 +25,7 @@ end
 begin
   require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    version = (Blacksmith::Modulefile.new).version
-    config.future_release = "v#{version}" if version =~ /^\d+\.\d+.\d+$/
+    config.future_release = Blacksmith::Modulefile.new.version
     config.header = <<~HEADER
       # Changelog
 


### PR DESCRIPTION
We tag our versions without prepending a 'v', so the future version is
what we can see in the metadata.json file, verbatim.