### PR TITLE
Tell rubocop to ignore the modules directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+AllCops:
+  Exclude:
+    - "modules/**/*"


### PR DESCRIPTION
When running the test suite on a system where msync has been used, we do
not want Rubocop to try to verify the modules code against the rules in
the modulesync_config Rubocop configuration.