### PR TITLE
Run CI on push to repositories main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,12 @@
 name: Continuous Integration
 
 on:
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ci:

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -3,7 +3,15 @@
 
 name: CI
 
-on: pull_request
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
 
 jobs:
   setup_matrix:


### PR DESCRIPTION
Run the test suites when new commits are pushed on the `master` branch.

With git now defaulting to `main`, prepare for future repositories by
also tracking this branch.