### PR TITLE
Switch back to upstream github_changelog_generator

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -19,8 +19,7 @@ Gemfile:
       - gem: voxpupuli-acceptance
     ':release':
       - gem: github_changelog_generator
-        git: https://github.com/voxpupuli/github-changelog-generator
-        branch: voxpupuli_essential_fixes
+        version: '>= 1.16.1'
       - gem: puppet-blacksmith
       - gem: voxpupuli-release
       - gem: puppet-strings


### PR DESCRIPTION
Just like the voxpupuli organization, switch back to upstream.