### PR TITLE
Always use rspec for mocking

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -3,6 +3,10 @@
 #
 # frozen_string_literal: true
 
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 require 'rspec-puppet-facts'


### PR DESCRIPTION
puppetlabs_spec_helper defaults to mocha and when both are loaded,
strang things happen (depending on the loading order some unit test can
mysteriously fail).

We are more used to rspec so always use this.
