### PR TITLE
Default to the latest Puppet version

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -8,7 +8,7 @@
 .travis.yml:
   delete: true
 Gemfile:
-  puppet_version: '~> 6.0'
+  puppet_version: '~> 7.0'
   required:
     ':test':
       - gem: voxpupuli-test


### PR DESCRIPTION
Some tooling will not work with old dependencies Puppet 6 depends on,
e.g. github_changelog_generator.  Default to Puppet 7 if no version is
explicitly set.
