### PR TITLE
Sync with Vox Pupuli

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -18,29 +18,25 @@ Gemfile:
   required:
     ':test':
       - gem: voxpupuli-test
-        version: '~> 5.4'
+        version: '~> 6.0'
       - gem: coveralls
       - gem: simplecov-console
       - gem: puppet_metadata
-        version: '~> 2.0'
+        version: '~> 3.0'
     ':development':
       - gem: guard-rake
       - gem: overcommit
         version: '>= 0.39.1'
     ':system_tests':
       - gem: voxpupuli-acceptance
-        version: '~> 1.0'
+        version: '~> 2.0'
     ':release':
       - gem: github_changelog_generator
         version: '>= 1.16.1'
-        ruby-version: '2.5'
-        ruby-operator: '>='
       - gem: voxpupuli-release
-        version: '~> 2.0'
+        version: '~> 3.0'
       - gem: faraday-retry
         version: '~> 2.1'
-        ruby-version: '2.6'
-        ruby-operator: '>='
 Rakefile:
   config.user: opus-codium
   # config.project: PROJECT
@@ -123,6 +119,8 @@ spec/spec_helper.rb:
   mock_with: false
 spec/spec_helper_acceptance.rb:
   unmanaged: true
+  configure_beaker:
+    modules: ':metadata'
 CONTRIBUTING.md:
   delete: true
 .gitlab-ci.yml:
@@ -137,3 +135,7 @@ pdk.yaml:
   delete: true
 .tool-versions:
   delete: true
+Modulefile:
+  delete: true
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/spec_helper_acceptance.rb.erb
+++ b/moduleroot/spec/spec_helper_acceptance.rb.erb
@@ -5,6 +5,8 @@
 
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
-configure_beaker
+<%- unless @configs['configure_beaker'].nil? -%>
+configure_beaker(modules: <%= @configs['configure_beaker']['modules'] || ':metadata' %>)
 
+<%- end -%>
 Dir['./spec/support/acceptance/**/*.rb'].sort.each { |f| require f }


### PR DESCRIPTION
Some CI failure we currently experience are fixed by updating our test dependencies, e.g.

```
       error during compilation: Evaluation Error: Error while evaluating a Resource Statement, Could not autoload puppet/type/service: Could not autoload puppet/provider/service/bsd: Could not autoload puppet/provider/service/init: undefined method `downcase' for nil:NilClass (file: /home/runner/work/puppet-dehydrated/puppet-dehydrated/spec/fixtures/modules/apache/manifests/service.pp, line: 28, column: 5) on node fv-az573-263.jpecsxrkdpfu5iw1uidn2h5lnh.bx.internal.cloudapp.net
```

Sync with Vox Pupuli config, so that we can msync update our modules and fix these tests and release new versions of the module compatible with Puppet 8.