### PR TITLE
Add postsrsd module

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -7,6 +7,7 @@
 - puppet-deploy
 - puppet-firefox
 - puppet-odoo
+- puppet-postsrsd
 - puppet-puppetvpn
 - puppet-rwhod
 - puppet-sogo


### PR DESCRIPTION
Module is already available on the Puppet forge:
https://forge.puppetlabs.com/modules/opuscodium/postsrsd

Only support PostSRSd 2.x, required for my FreeBSD setup. We do not use it directly in the Opus infra ATM and will not use it before Debian 13 in the best case.