### PR TITLE
Remove puppet-puppetvpn from manager modules

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -9,7 +9,6 @@
 - puppet-nextcloud
 - puppet-odoo
 - puppet-postsrsd
-- puppet-puppetvpn
 - puppet-rwhod
 - puppet-sogo
 - puppet-ssh


### PR DESCRIPTION
The module was archived a while ago.
